### PR TITLE
Fix: Whitelist new backend URL and update in sidebar

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -7,7 +7,8 @@
     "https://www.googleapis.com/auth/script.external_request"
   ],
   "urlFetchWhitelist": [
-    "https://excel-addin-backend-1088354707719.asia-south1.run.app/"
+    "https://excel-addin-backend-1088354707719.asia-south1.run.app/",
+    "https://excel-addin-backend-o5molvd7pa-el.a.run.app/"
   ],
   "addOns": {
     "common": {

--- a/sidebar.html
+++ b/sidebar.html
@@ -87,7 +87,7 @@
   </div>
 
   <script>
-    const backendUrl = "https://excel-addin-backend-1088354707719.asia-south1.run.app";
+    const backendUrl = "https://excel-addin-backend-o5molvd7pa-el.a.run.app";
     const columns = ["Date", "Open", "High", "Low", "Close", "Volume", "1_Day_%_Change", "3_Day_%_Change", "1_Week_%_Change", "1_Month_%_Change", "3_Month_%_Change", "6_Month_%_Change", "1_Year_%_Change", "Price_MA_10", "Price_MA_20", "Price_MA_50", "Price_MA_100", "Price_MA_200", "Volatility_10", "Volatility_20", "Volatility_50", "Volatility_100", "Volatility_200", "Volume_MA_10", "Volume_MA_20", "Volume_MA_50", "Volume_MA_100", "Volume_MA_200"];
 
     function displayMessage(text, isError = false) {


### PR DESCRIPTION
The script was failing with a `urlFetchWhitelist` error because the backend URL had changed and the new URL was not whitelisted in the `appsscript.json` manifest.

This commit:
- Adds the new backend URL (`https://excel-addin-backend-o5molvd7pa-el.a.run.app/`) to the `urlFetchWhitelist` in `appsscript.json`.
- Updates the hardcoded `backendUrl` variable in `sidebar.html` to the new URL to maintain consistency.